### PR TITLE
HEADLESS-465: Use main not master; troubleshooting for branches

### DIFF
--- a/guides/getting-started/deploy-app.md
+++ b/guides/getting-started/deploy-app.md
@@ -36,10 +36,10 @@ Once you have the repo created in GitHub, run:
 
 ```
 $ git remote add origin YOUR_GITHUB_URL
-$ git push -u origin master
+$ git push -u origin main
 ```
 
-Using this guide, you will connect your current branch (`master`) to the platform for deployment, but you are free to set this up however you'd like. Ideally, you will have multiple branches that represent environments like production, staging, and development, but for the purposes of this guide, we're going to focus on a single branch/environment.
+Using this guide, you will connect your current branch (`main`) to the platform for deployment, but you are free to set this up however you'd like. Ideally, you will have multiple branches that represent environments like production, staging, and development, but for the purposes of this guide, we're going to focus on a single branch/environment.
 
 ## Authenticate with the Platform
 
@@ -86,7 +86,7 @@ Copy this basic configuration into your `wpe.json` file:
   "environments": [
     {
       "name": "Production",
-      "branch": "master",
+      "branch": "main",
       "wp_environment_name": "YOUR WordPress environment name",
       "secrets": [
         {

--- a/guides/troubleshooting/README.md
+++ b/guides/troubleshooting/README.md
@@ -74,3 +74,16 @@ After the platform pulls your code and runs `npm i`, it will execute the `wpe-bu
 ```
 
 Note that it is acceptable to have a blank script (i.e. `"wpe-build": ""`), but the script must exist.
+
+## Check your branch configuration
+
+If the branch that you are using GitHub does not match the branch that you have configured for your environment, the platform will not build your software. Double check that the branch configured for the environment matches the branch you're committing to in GitHub:
+
+```
+$ wpe alpha apps get APP_NAME
+```
+
+This command will list your app and the environment configurations with the branch names.
+
+**Note:** [GitHub is changing](https://github.com/github/renaming) the default branch name from `master` to `main`. Depending on where your organization is on that journey, and when your repository was created, your default may be `master` or `main`. WP Engine supports the use of the more inclusive `main`, so this guide uses `main` in examples. This may be a source of inconsistency.
+


### PR DESCRIPTION
The recent GitHub changes to use `main` not `master` are both inconsistent with this guide and potentially a source of confusion for our users. Indeed, we've had at least one internal user complain that their app is not building and the cause was a mismatch in branch names (though not `main` vs. `master`; in this case it was `develop` vs. `master`).

This change:

 * Changes existing references to `master` to `main`.
 * Adds a troubleshooting explanation that shows how to check your branches and explicitly notes the mismatch that the changes GitHub are making could create.