### PR TITLE
docs: WP_URL to WORDPRESS_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Here's an example configuration for a typical app with a Production and Developm
       "wp_environment_name": "headlesswpe",
       "domains": ["yourdomain.com"],
       "env_variables": [
-        { "key": "WP_URL", "value": "https://headlesswpe.wpengine.com" }
+        { "key": "WORDPRESS_URL", "value": "https://headlesswpe.wpengine.com" }
       ]
     },
     {
@@ -59,7 +59,7 @@ Here's an example configuration for a typical app with a Production and Developm
       "branch": "dev",
       "wp_environment_name": "headlesswpe-dev",
       "env_variables": [
-        { "key": "WP_URL", "value": "https://headlesswpe-dev.wpengine.com" }
+        { "key": "WORDPRESS_URL", "value": "https://headlesswpe-dev.wpengine.com" }
       ]
     }
   ]

--- a/guides/getting-started/deploy-app/README.md
+++ b/guides/getting-started/deploy-app/README.md
@@ -91,7 +91,7 @@ Copy this basic configuration into your `wpe.json` file:
       "wp_environment_name": "YOUR WordPress environment name",
       "env_variables": [
         {
-          "key": "WP_URL",
+          "key": "WORDPRESS_URL",
           "value": "https://yoururl"
         }
       ]

--- a/reference/cli/wpe/alpha/apps/create/README.md
+++ b/reference/cli/wpe/alpha/apps/create/README.md
@@ -47,7 +47,7 @@ The simplest way to create your new app is by configuring a `wpe.json` file with
       "domains": ["yourdomain.com"],
       "env_variables": [
         {
-          "key": "WP_URL",
+          "key": "WORDPRESS_URL",
           "value": "https://yoururl"
         }
       ]

--- a/reference/cli/wpe/alpha/apps/get/README.md
+++ b/reference/cli/wpe/alpha/apps/get/README.md
@@ -35,7 +35,7 @@ myapp                   organization/myapp
 
 ENVIRONMENT     BRANCH  URL                                                             ID                              STATE
 Development     master  https://hbq5fb1hu43epj6apiu2enakm.js.wpenginepowered.com        bq5fb1hu43epj6apiu2enakm        deployed
-ENVIRONMENT VARIABLES: WP_URL
+ENVIRONMENT VARIABLES: WORDPRESS_URL
 STATUS
 ```
 

--- a/reference/cli/wpe/alpha/apps/update/README.md
+++ b/reference/cli/wpe/alpha/apps/update/README.md
@@ -44,7 +44,7 @@ The simplest way to update your app is by configuring a `wpe.json` file with the
       "wp_environment_name": "YOUR WordPress environment name",
       "env_variables": [
         {
-          "key": "WP_URL",
+          "key": "WORDPRESS_URL",
           "value": "https://yoururl"
         }
       ]


### PR DESCRIPTION
Current env var examples use `WP_URL`, but the getting-started and preview examples in the headless-framework expect `WORDPRESS_URL`.