### PR TITLE
Update references of gqty.com to gqty.dev/docs

### DIFF
--- a/faustjs/next/guides/fetching-data.mdx
+++ b/faustjs/next/guides/fetching-data.mdx
@@ -6,7 +6,7 @@ description: Faust.js makes fetching data from Headless WordPress incredibly eas
 
 > **NOTE**: If you followed the instructions in the [Getting Started with Next.js](../getting-started.mdx) guide, you already have a working instance of the client. The following guide assumes you are setting up a client on an already existing application.
 
-Faust.js uses [GQty](https://gqty.com/react/fetching-data) as the primary way to fetch data from Headless WordPress. GQty is a [proxy-based](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) GraphQL client. GQty [preforms an invisible or skeleton render](https://gqty.com/intro/how-it-works) to identify what data is needed.
+Faust.js uses [GQty](https://gqty.dev/docs/react/fetching-data) as the primary way to fetch data from Headless WordPress. GQty is a [proxy-based](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) GraphQL client. GQty [preforms an invisible or skeleton render](https://gqty.dev/docs/intro/how-it-works) to identify what data is needed.
 
 ## Setting Up Your Client
 

--- a/faustjs/next/reference/hooks-for-fetching-data.mdx
+++ b/faustjs/next/reference/hooks-for-fetching-data.mdx
@@ -219,13 +219,14 @@ export default function Preview() {
 
 GQty publishes the following hooks that can be used for custom queries, mutations, or subscriptions:
 
-- [`useQuery`](https://gqty.com/react/fetching-data#usequery)
+- [`useQuery`](https://gqty.dev/docs/react/fetching-data#usequery)
   - Make any query request to the Headless WordPress API
-- [`useLazyQuery`](https://gqty.com/react/fetching-data#uselazyquery)
-- [`useTransactionQuery`](https://gqty.com/react/fetching-data#usetransactionquery)
-- [`useMutation`](https://gqty.com/react/fetching-data#usemutation)
+- [`useLazyQuery`](https://gqty.dev/docs/react/fetching-data#uselazyquery)
+- [`useTransactionQuery`](https://gqty.dev/docs/react/fetching-data#usetransactionquery)
+<!-- The sections below do not exist on gqty.dev as of 08/19/2021 -->
+<!-- - [`useMutation`](https://gqty.dev/docs/react/fetching-data#usemutation)
   - Make any mutation request to the Headless WordPress API
-- [`useSubscription`](https://gqty.com/react/fetching-data#usesubscription)
+- [`useSubscription`](https://gqty.dev/docs/react/fetching-data#usesubscription) -->
 
 For example, you may want to get a list of your content types:
 

--- a/faustjs/tutorial/setup-faustjs.mdx
+++ b/faustjs/tutorial/setup-faustjs.mdx
@@ -102,7 +102,7 @@ Replace the `NEXT_PUBLIC_WORDPRESS_URL` value with the URL of your WordPress sit
 
 ### Configure GQty
 
-We use [GQty](https://gqty.com) as our GraphQL client. To configure GQty, we need to create a `gqty.config.js` file in the root of our project.
+We use [GQty](https://gqty.dev/docs/) as our GraphQL client. To configure GQty, we need to create a `gqty.config.js` file in the root of our project.
 
 ```js title=gqty.config.js
 require("dotenv").config();


### PR DESCRIPTION
Also had to comment out a couple of links that do not currently exist on `gqty.dev`.