### PR TITLE
Include node 16 as supported and default version

### DIFF
--- a/node-engine/guides/getting-started.mdx
+++ b/node-engine/guides/getting-started.mdx
@@ -46,6 +46,6 @@ Node.js uses npm for its package management, which allows you to set the version
 }
 ```
 
-The supported versions of Node are **10, 12, 14 and 16**. Specifying a Node version below the minimum supported version will default to the minimum supported version (10); setting a higher version will default to the maximum supported version (16). To ensure your project is built with a version of your choice, make sure to include your desired settings in "engines" section of your package.json.
+The supported versions of Node are **12, 14 and 16**. Specifying a Node version below the minimum supported version will default to the minimum supported version (12); setting a higher version will default to the maximum supported version (16). To ensure your project is built with a version of your choice, make sure to include your desired settings in "engines" section of your package.json.
 
 **NOTE:** On April 10, 2021, Node version 10 will no longer be supported.

--- a/node-engine/guides/getting-started.mdx
+++ b/node-engine/guides/getting-started.mdx
@@ -46,6 +46,6 @@ Node.js uses npm for its package management, which allows you to set the version
 }
 ```
 
-The supported versions of Node are **10, 12, and 14**. Specifying a Node version below the minimum supported version will default to the minimum supported version (10); setting a higher version will default to the maximum supported version (14).
+The supported versions of Node are **10, 12, 14 and 16**. Specifying a Node version below the minimum supported version will default to the minimum supported version (10); setting a higher version will default to the maximum supported version (16). To ensure your project is built with a version of your choice, make sure to include your desired settings in "engines" section of your package.json.
 
 **NOTE:** On April 10, 2021, Node version 10 will no longer be supported.


### PR DESCRIPTION
Currently, we default all applications to be built with Node 16 - so we need to make sure this info is included in the docs.