### PR TITLE
Info about the need to upgrade CLI

### DIFF
--- a/node-engine/introduction.mdx
+++ b/node-engine/introduction.mdx
@@ -134,5 +134,7 @@ If the installation was successful, your terminal applications returns:
 ```bash
 wpe version vX.X.X
 ```
+NOTE: In case your version is lower than `1.0.0` (e.g. 0.9.9) you need to upgrade your CLI using `npm i @wpengine/headless-cli -g` command. Versions lower than `1.0.0` will stop being supported starting 09/30/2021.
 
 You'll now be able to follow the other guides and tutorials on this site, as well as use any command in the [CLI reference](./reference/cli/wpe).
+

--- a/node-engine/introduction.mdx
+++ b/node-engine/introduction.mdx
@@ -134,7 +134,6 @@ If the installation was successful, your terminal applications returns:
 ```bash
 wpe version vX.X.X
 ```
-NOTE: In case your version is lower than `1.0.0` (e.g. 0.9.9) you need to upgrade your CLI using `npm i @wpengine/headless-cli -g` command. Versions lower than `1.0.0` will stop being supported starting 09/30/2021.
+NOTE: If your version is lower than `1.0.0` (e.g. 0.9.9) you need to upgrade your CLI using `npm i @wpengine/headless-cli -g` command. Support for versions lower than 1.0.0 will stop on 09/30/2021.
 
 You'll now be able to follow the other guides and tutorials on this site, as well as use any command in the [CLI reference](./reference/cli/wpe).
-


### PR DESCRIPTION
We'll soon stop supporting versions lower than 1.0.0 - user will have to upgrade their CLI to the latest version in case they still use the outdated one.