### PR TITLE
Use `main` branch for creating example app

### DIFF
--- a/node-engine/guides/create-app.mdx
+++ b/node-engine/guides/create-app.mdx
@@ -20,7 +20,7 @@ Install our Next.js Getting Started example using the following command:
 
 ```bash
 npx create-next-app \
-    -e https://github.com/wpengine/faustjs/tree/canary \
+    -e https://github.com/wpengine/faustjs/tree/main \
     --example-path examples/next/getting-started \
     --use-npm \
     my-app
@@ -36,7 +36,7 @@ cd my-app
 
 ```ps
 npx create-next-app `
-    -e https://github.com/wpengine/faustjs/tree/canary `
+    -e https://github.com/wpengine/faustjs/tree/main `
     --example-path examples/next/getting-started `
     --use-npm `
     my-app && cd my-app


### PR DESCRIPTION
The Faust.js team is preparing to move distribution of our Next.js example project from `canary` to `main` sometime within the next week. As a result, the recommended `npx` command for creating a new faustjs/next project will soon be changing. The faustjs.org docs will be updated to reflect this change once we officially make the switch, but we wanted to give a heads up wherever we could. Installing from `main` is already supported and preferred, so I went ahead and made the update for the node engine docs.