### PR TITLE
ORN-770 add getting started

### DIFF
--- a/content-engine/getting-started.mdx
+++ b/content-engine/getting-started.mdx
@@ -52,18 +52,14 @@ Content Engine, like other WordPress customizations, uses a plugin to enable its
 - URL: https://aql.wpengine.com/sync/{your_ce_site}/graphql
 - Access Token
 
-```
-TODO insert image
-```
+![WPE Content Engine Plugin](./images/ce-plugin.png)
 
 ## First-time Content Sync
 
 With Content Engine fully integrated into your WordPress instance, you can sync your data with
 WordPress CLI. Open a terminal on the WordPress instance and enter `wp ce sync_data`:
 
-```
-TODO insert image
-```
+![Content Engine sync](./images/ce-sync.png)
 
 Content Engine then syncs users, posts, and pages. Upon completion, CLI returns a message `Success syncing all data`.
 
@@ -103,9 +99,7 @@ query Posts {
 
 3. On the right-hand side of the console, all posts show in a JSON format, which includes all metadata related to each post.
 
-```
-TODO insert image
-```
+![AQL query](./images/aql-query.png)
 
 ## Content Availability
 

--- a/content-engine/getting-started.mdx
+++ b/content-engine/getting-started.mdx
@@ -1,0 +1,126 @@
+---
+slug: /content-engine/getting-started
+title: Content Engine - Getting Started
+description: When using the WordPress API through WPGraphQL, pulling content from WordPress can be slow and cumbersome. Content Engine increases the speed from which your front-end applications retrieve WordPress content.
+---
+
+# Atlas - Content Engine (Beta)
+
+## Developer Documentation
+
+- Content Engine is currently in beta and is invite-only. If you're interested in exploring and testing Content Engine, fill out an [interest form](https://docs.google.com/forms/d/e/1FAIpQLSeFKjb1i1t8dbXIQd35NDzoSNKpx_1nWuf72FXmbj9WYAqLYw/viewform).
+
+## What is the Content Engine?
+
+Retrieving content data for your headless site using WordPress APIs is very slow and impacts performance.
+
+Atlas Content Engine dramatically accelerates the speed and scalability by making the core, public-facing content available at the edge and providing simplified schema for faster data retrieval.
+
+### Why Content Engine?
+
+Content Engine offers the following benefits:
+
+1. Modern GraphQL-based APIs to access content from WordPress
+2. Accelerate content retrieval by 5X
+3. 10 times scalable APIs than current solutions
+4. Real-time content synchronization & availability
+5. A logical, easy-to-use schema for content retrieval
+
+## Getting Started
+
+### Prerequisites
+
+1. A WP Engine account is required to use Content Engine.
+   If you do not have an
+   account, please reach out to [ce-beta@wpengine.com](mailto:ce-beta@wpengine.com).
+2. You’ll also need an instance of WordPress CMS for testing.
+
+When you enroll for testing Content Engine, you’ll receive an email with:
+
+- A PDF for getting started
+- A zip file with the Content Engine plugin
+- Your AQL URL and Access Token.
+
+## Plugin Installation
+
+Content Engine, like other WordPress customizations, uses a plugin to enable its use.
+
+1. In your WordPress admin panel, install the **Atlas Content Engine** plugin. A link to download the plugin is provided in the email.
+2. Install and activate the plugin. After activation, **WPE Content Engine** appears in the left navigation panel.
+3. On the WPE Content Engine settings, set the following (See the email sent to you during enrollment):
+
+- URL: https://aql.wpengine.com/sync/{your_ce_site}/graphql
+- Access Token
+
+```
+TODO insert image
+```
+
+## First-time Content Sync
+
+With Content Engine fully integrated into your WordPress instance, you can sync your data with
+WordPress CLI. Open a terminal on the WordPress instance and enter `wp ce sync_data`:
+
+```
+TODO insert image
+```
+
+Content Engine then syncs users, posts, and pages. Upon completion, CLI returns a message `Success syncing all data`.
+
+If you do not receive this message, ensure that your access token is set correctly and that the Content Engine plugin is installed.
+
+# Atlas Query Language (AQL)
+
+## What is AQL?
+
+AQL provides an intuitive schema for modern javascript developers and the query language is based on GraphQL. AQL retrieves content with low latency and high throughput, ensuring the site’s SEO and maximizes the user experience.
+
+## Using AQL
+
+To begin querying data with AQL:
+
+1. Navigate to your site’s AQL query builder URL. You will have received this unique URL in the email - e.g. https://aql.wpengine.com/sites/{your_CE_site_name}/graphql
+2. Upon entering the endpoint, the AQL console appears. Use the following query to retrieve posts from your WordPress instance:
+
+```graphql
+query Posts {
+  posts {
+    wpId
+    slug
+    title
+    excerpt
+    urlPath
+    publishedAt
+    author {
+      displayName
+      avatar {
+        url
+      }
+    }
+  }
+}
+```
+
+3. On the right-hand side of the console, all posts show in a JSON format, which includes all metadata related to each post.
+
+```
+TODO insert image
+```
+
+## Content Availability
+
+Currently, Content Engine supports retrieval for the following:
+
+- Posts
+- Pages
+- Users
+
+As Content Engine matures, more WordPress content will become available. If you have suggestions for what type of content you would like to see, fill out this [feedback form](https://docs.google.com/forms/d/e/1FAIpQLSecvuZ_EMiTIOlTSwcW1JnPQcFbAcCOwGlhURkzBI8Ps9vFzA/viewform).
+
+## Feedback
+
+**Question?** - Reach us at [ce-beta@wpengine.com](mailto:ce-beta@wpengine.com)
+
+**Feedback** - We value your feedback and it will help shape the future of Content Engine
+
+- [Provide online feedback](https://docs.google.com/forms/d/e/1FAIpQLSecvuZ_EMiTIOlTSwcW1JnPQcFbAcCOwGlhURkzBI8Ps9vFzA/viewform)


### PR DESCRIPTION
Added 'getting started' documentation for Content Engine

**EDIT**

Some context around this update;
* This PR moves text already supplied to Content Engine trail users via PDF into a repo where it will get published to a website
* This content can then be;
  * linked to via the signup email (rather than via PDF attachment)
  * maintained like the rest of the documentation instead of pusblishing changes to a Google store
* Once published via this repo, the content is not directly linked to from any other document and so will not be navigable via the Developer site.
* The content in this PR is pre-existing text only and will be subject to further revision going forward.
* This update is purely to provide a URL endpoint to link to while we modify our signup process and email content