### PR TITLE
Update terminology

### DIFF
--- a/atlas-search/introduction.mdx
+++ b/atlas-search/introduction.mdx
@@ -35,7 +35,7 @@ Our new ‘Atlas Search’ product is designed to help here: It aims to improve 
 #### General Prerequisites:
 1. You are an existing or “eval” Atlas customer.
 2. You have an instance of WordPress on a WPEngine ‘Portal’ ‘site’ with a target ‘environment’ & you can access that environment’s ‘WP Admin’ panel.
-3. In the target environment’s WP Admin panel, you have downloaded & activated the [WP-GraphQL](https://www.wpgraphql.com/) plugin from WP Plugin Store.
+3. In the target environment’s WP Admin panel, you have downloaded & activated the [WP-GraphQL](https://wordpress.org/plugins/wp-graphql/) plugin from the WordPress.org plugin repository.
 
 #### Atlas Search Prerequisites (Unless configured via ‘Atlas Blueprints’):
 1. You have enrolled for Atlas Search, via:


### PR DESCRIPTION
Changing "Plugin Store" to "WordPress.org plugin repository".