### PR TITLE
[NEB-1154] Atlas V2 Build docs

### DIFF
--- a/atlas/config.json
+++ b/atlas/config.json
@@ -79,6 +79,11 @@
           "type": "doc",
           "label": "Cache-Control Headers",
           "filePath": "/atlas/customization/cache-control.mdx"
+        },
+        {
+          "type": "doc",
+          "label": "Configuring Atlas Builds",
+          "filePath": "/atlas/customization/builds.mdx"
         }
       ]
     },

--- a/atlas/customization/builds.mdx
+++ b/atlas/customization/builds.mdx
@@ -1,0 +1,73 @@
+---
+slug: /atlas/customization/builds
+title: Configuring Atlas Builds
+description: Learn how to configure builds on the Atlas platform
+---
+
+Here we describe ways of configuring the Atlas build system for your needs. You can configure the Node.js environment, how dependencies are installed and what command is used to build your app.
+
+## Setting a custom version of Node.js, npm and yarn
+
+### Node.js
+
+By default, Atlas uses the latest LTS Node.js version which is v16. The timeline of LTS releases is tracked [here.](https://nodejs.org/en/about/releases/) Currently we maintain support for Node.js v12, v14, v16.
+
+To set a custom version of Node.js, use the [engines](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#engines) field in the `package.json` file. For example here is how to set it to use Node.js 14.
+```json
+"engines": {
+  "node": "v14"
+},
+```
+
+To see what version of Node.js you are using on your local machine use the following command:
+```bash
+$ node --version
+v16.15.0
+```
+
+### npm
+
+The default version of npm used depends on the version of Node.js you have selected. You can use [this page](https://nodejs.org/en/download/releases/) to search which version of npm comes with a particular version of Node.js. Alternatively to see what version you have installed locally use:
+```bash
+$ npm --version
+8.11.0
+```
+
+Atlas looks for your npm version in two places. The first is the `engines` field in the `package.json` file:
+```json
+"engines": {
+  "npm": "8.11.0"
+}
+```
+
+An alternative way to set npm is to use the `packageManager` field in the `package.json` file. Note the difference in format compared to the `engines` field above.
+```json
+"packageManager": "npm@8.11.0"
+```
+
+### yarn
+
+Atlas looks for a `yarn.lock` file to decide if your app is using yarn. If no `yarn.lock` file is present then it defaults to `npm`. 
+
+Currently only yarn classic (v1) is supported with the default version on Atlas being `v1.22.18`. Other versions of yarn classic can be selected by using the `packageManager` field in `package.json`
+```bash
+"packageManager": "yarn@1.22.16"
+```
+
+
+## Installing Dependencies
+
+If you have checked in the `package-lock.json` file to your repo Atlas runs `npm ci` to install package dependencies. It is recommended to include this file for a number of reasons:
+**Reliability:** exact dependency versions are in the `package-lock.json` file which ensures the Atlas environment mirrors the local environment
+**Speed:** there is no need to create a list of dependencies before installing them. Dependencies are directly installed from  `package-lock.json`. 
+
+Note: if the `package-lock.json` and `package.json` are out of sync the install will fail. To fix this error please run `npm install` to update the dependencies
+
+If the `package-lock.json` file is not present then `npm install` is run.
+
+## Build Command
+
+The build command can be configured 3 ways. In order of priority they are:
+1.  `npm run-script ATLAS_BUILD_SCRIPT` - Atlas looks for the `ATLAS_BUILD_SCRIPT` environment variable. For example if `ATLAS_BUILD_SCRIPT=my-build` we will run `npm run-script my-build`
+2.  `npm run-script wpe-build` - if it exists in `package.json`
+3.  `npm run-script build` - if it exists in `package.json`

--- a/atlas/customization/builds.mdx
+++ b/atlas/customization/builds.mdx
@@ -4,19 +4,32 @@ title: Configuring Atlas Builds
 description: Learn how to configure builds on the Atlas platform
 ---
 
-Here we describe ways of configuring the Atlas build system for your needs. You can configure the Node.js environment, how dependencies are installed and what command is used to build your app.
+This guide describes how to configure the Atlas build system for your applications.
 
-## Setting a custom version of Node.js, npm and yarn
+## Setting a custom version of Node.js, npm and Yarn
 
 ### Node.js
 
-By default, Atlas uses the latest LTS Node.js version which is v16. The timeline of LTS releases is tracked [here.](https://nodejs.org/en/about/releases/) Currently we maintain support for Node.js v12, v14, v16.
+By default, Atlas uses the latest v16 LTS release of Node.js. Currently Atlas supports Node.js v12, v14 and v16.
 
-To set a custom version of Node.js, use the [engines](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#engines) field in the `package.json` file. For example here is how to set it to use Node.js 14.
+To set a custom version of Node.js, use the [engines](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#engines) field in the `package.json` file. For example, here is how to deploy your application Node.js 16:
 ```json
 "engines": {
-  "node": "v14"
+  "node": "16.15.0"
 },
+```
+Note: Atlas builds use [Semantic Versioning](https://docs.npmjs.com/about-semantic-versioning) to specify the Node.js version. This can be used to specify a specific versions, a range of versions or a major version
+
+The version of Node.js in use on your builds can be found in the build output:
+```
+Node.js Setup:
+  Detecting Node.js version
+    Searching for the Node.js version in package.json => engines
+    Using Node.js "16.15.0" from the package.json engines field
+  
+  Installing Node.js
+  nodejs: Contributing to layer
+    Node.js v16.15.0 installed
 ```
 
 To see what version of Node.js you are using on your local machine use the following command:
@@ -24,50 +37,80 @@ To see what version of Node.js you are using on your local machine use the follo
 $ node --version
 v16.15.0
 ```
-
 ### npm
 
-The default version of npm used depends on the version of Node.js you have selected. You can use [this page](https://nodejs.org/en/download/releases/) to search which version of npm comes with a particular version of Node.js. Alternatively to see what version you have installed locally use:
-```bash
-$ npm --version
-8.11.0
-```
+The builds use the default version of npm that comes with the Node.js release selected. You can use [this page](https://nodejs.org/en/download/releases/) to search which version of npm comes with a particular version of Node.js. 
 
-Atlas looks for your npm version in two places. The first is the `engines` field in the `package.json` file:
+You can set a custom version of npm used in Atlas builds in two places. The first is the `engines` field in the `package.json` file. Similar to Node.js versions above, Atlas uses semver to specify the version used. Here is how to set it to use the latest version of npm v8:
 ```json
 "engines": {
-  "npm": "8.11.0"
+  "npm": "8"
 }
 ```
 
-An alternative way to set npm is to use the `packageManager` field in the `package.json` file. Note the difference in format compared to the `engines` field above.
+An alternative way to set npm is to use the `packageManager` field in the `package.json` file. Note the difference in format compared to the `engines` field above where the version must be an exact version of npm:
 ```json
 "packageManager": "npm@8.11.0"
 ```
 
-### yarn
+The version of npm being used on your builds can be found in the build output:
+```
+npm Setup:
+  Detecting npm version
+    Searching for the npm version in:
+     1. package.json => engines
+     2. package.json => packageManager
+    Using npm "8" from package.json engines field
+  
+  Installing npm
+    npm: Contributing to layer
+      npm v8.13.2 installed because it is the latest version that matches the constraint "8"
+```
 
-Atlas looks for a `yarn.lock` file to decide if your app is using yarn. If no `yarn.lock` file is present then it defaults to `npm`. 
-
-Currently only yarn classic (v1) is supported with the default version on Atlas being `v1.22.18`. Other versions of yarn classic can be selected by using the `packageManager` field in `package.json`
+To see what version you have installed locally use:
 ```bash
+$ npm --version
+8.11.0
+```
+### Yarn
+If the `yarn.lock` file is committed then yarn is used instead of npm to build your application. Currently only Yarn Classic (v1) is supported on Atlas builds. 
+
+If you want to set an exact version of Yarn use the `packageManager` field in `package.json`:
+```json
 "packageManager": "yarn@1.22.16"
 ```
 
+The version of npm being used on your builds can be found in the build output:
+```
+Yarn Setup:
+  Determining yarn version
+  Yarn v1.22.16 installed
+```
 
+Use this command to see what version you are using locally:
+```bash
+$ yarn --version
+1.22.16
+```
 ## Installing Dependencies
 
-If you have checked in the `package-lock.json` file to your repo Atlas runs `npm ci` to install package dependencies. It is recommended to include this file for a number of reasons:
-**Reliability:** exact dependency versions are in the `package-lock.json` file which ensures the Atlas environment mirrors the local environment
-**Speed:** there is no need to create a list of dependencies before installing them. Dependencies are directly installed from  `package-lock.json`. 
-
-Note: if the `package-lock.json` and `package.json` are out of sync the install will fail. To fix this error please run `npm install` to update the dependencies
+It is recommended to commit your `package-lock.json` file to version control. Once committed Atlas uses the lock file to run `npm ci` to install package dependencies which builds your app with the same dependencies used in your local dev environment.
 
 If the `package-lock.json` file is not present then `npm install` is run.
 
 ## Build Command
+This is the command which is run to build your application. Custom build commands can be set on Atlas and per environment.
 
 The build command can be configured 3 ways. In order of priority they are:
-1.  `npm run-script ATLAS_BUILD_SCRIPT` - Atlas looks for the `ATLAS_BUILD_SCRIPT` environment variable. For example if `ATLAS_BUILD_SCRIPT=my-build` we will run `npm run-script my-build`
-2.  `npm run-script wpe-build` - if it exists in `package.json`
-3.  `npm run-script build` - if it exists in `package.json`
+1.  `ATLAS_BUILD_SCRIPT` - Atlas builds look for the `ATLAS_BUILD_SCRIPT` environment variable. For example, `ATLAS_BUILD_SCRIPT=my-build` means `npm run my-build` will be run if using npm
+2.  `wpe-build` - if it exists in `package.json` then `npm run wpe-build` is run if using npm
+3.  `build` - if it exists in `package.json`
+
+Below is an example of how to set each build command:
+```json
+"scripts": {
+    "my-build": "next build",  // only run if ATLAS_BUILD_SCRIPT is set
+    "wpe-build": "next build",
+    "build": "next build",
+},
+```

--- a/atlas/customization/builds.mdx
+++ b/atlas/customization/builds.mdx
@@ -98,7 +98,7 @@ It is recommended to commit your `package-lock.json` file to version control. On
 
 If the `package-lock.json` file is not present then `npm install` is run.
 
-## Build Command
+## Custom Build Commands
 This is the command which is run to build your application. Custom build commands can be set on Atlas and per environment.
 
 The build command can be configured 3 ways. In order of priority they are:


### PR DESCRIPTION
There are no existing docs for the v2 builds since they have been released. This PR adds those which cover configuring the builds such as using custom versions of node/npm/yarn and modifying the build command