### PR TITLE
[NEB-1342] [NEB-1358] Add docs for build environment variables

### DIFF
--- a/atlas/additional-guides/troubleshooting-builds.mdx
+++ b/atlas/additional-guides/troubleshooting-builds.mdx
@@ -46,7 +46,7 @@ The logging output available in this pane can be extremely useful for tracking d
 
 #### Logging Debug Mode
 
-Debug logging can be enabled for builds to aid with troubleshooting issues. This adds extra information to the log output such as listing npm installed packages and prints your `package.json`. This is useful if you are contacting support
+Debug logging can be enabled for builds to aid with troubleshooting issues. This adds extra information to the log output such as listing npm installed packages and prints your `package.json`. This is useful if you are contacting support.
 
 To enable debug mode for a build, set the environment variable `ATLAS_BUILD_DEBUG=true` and rebuild your app. The log output will start with this line once debug mode is enabled:
 ```

--- a/atlas/additional-guides/troubleshooting-builds.mdx
+++ b/atlas/additional-guides/troubleshooting-builds.mdx
@@ -44,6 +44,15 @@ The logging output pane labeled `Logs` captures all of the logging output from y
 
 The logging output available in this pane can be extremely useful for tracking down any issues that are related to your dependencies or their installation.
 
+#### Logging Debug Mode
+
+Debug logging can be enabled for builds to aid with troubleshooting issues. This adds extra information to the log output such as listing npm installed packages and prints your `package.json`. This is useful if you are contacting support
+
+To enable debug mode for a build, set the environment variable `ATLAS_BUILD_DEBUG=true` and rebuild your app. The log output will start with this line once debug mode is enabled:
+```
+Debug mode enabled this can cause builds to be slow
+```
+
 ### Accessing Prior Builds
 
 If you have examined the logging and error output for your build, and still aren't sure what the issue is, a helpful next step could be to compare the logging or commit histories between your current failed build and the last successful build. You can find a list of your environment's build history on the detail page for that environment.

--- a/atlas/customization/builds.mdx
+++ b/atlas/customization/builds.mdx
@@ -116,7 +116,7 @@ Below is an example of how to set each build command:
 ```
 
 ## Custom Start Commands
-The start command is run to start your Node application once it is deployed. By default Atlas runs the `start` script in `package.json`. This can be overridden by setting the `ATLAS_START_SCRIPT` environment variable. For example, `ATLAS_START_SCRIPT=start-dev` means `next dev` will be run instead of `next start`
+The start command is run to start your Node application once it is deployed. By default Atlas runs the `start` script in `package.json`. This can be overridden by setting the `ATLAS_START_SCRIPT` environment variable. For example, `ATLAS_START_SCRIPT=start-dev` means `next dev` will be run instead of `next start` with the package.json below
 
 ```json
 "scripts": {

--- a/atlas/customization/builds.mdx
+++ b/atlas/customization/builds.mdx
@@ -114,3 +114,13 @@ Below is an example of how to set each build command:
     "build": "next build",
 },
 ```
+
+## Custom Start Commands
+The start command is run to start your Node application once it is deployed. By default Atlas runs the `start` script in `package.json`. This can be overridden by setting the `ATLAS_START_SCRIPT` environment variable. For example, `ATLAS_START_SCRIPT=start-dev` means `next dev` will be run instead of `next start`
+
+```json
+"scripts": {
+    "start": "next start",
+    "start-dev": "next dev",
+},
+```

--- a/atlas/customization/builds.mdx
+++ b/atlas/customization/builds.mdx
@@ -116,7 +116,7 @@ Below is an example of how to set each build command:
 ```
 
 ## Custom Start Commands
-The start command is run to start your Node application once it is deployed. By default Atlas runs the `start` script in `package.json`. This can be overridden by setting the `ATLAS_START_SCRIPT` environment variable. For example, `ATLAS_START_SCRIPT=start-dev` means `next dev` will be run instead of `next start` with the package.json below
+The start command is run to start your Node application once it is deployed. By default Atlas runs the `start` script in `package.json`. This can be overridden by setting the `ATLAS_START_SCRIPT` environment variable. For example, `ATLAS_START_SCRIPT=start-dev` means `next dev` will be run instead of `next start` with the package.json below:
 
 ```json
 "scripts": {


### PR DESCRIPTION
We've are adding documentation for the environment variables that can be set in Atlas by customers., `ATLAS_BUILD_DEBUG` and `ATLAS_START_SCRIPT`, which have been added to atlas recently

https://wpengine.atlassian.net/browse/NEB-1358
https://wpengine.atlassian.net/browse/NEB-1342