### PR TITLE
Change from 'sendto:' to form URL

### DIFF
--- a/atlas/customization/builds.mdx
+++ b/atlas/customization/builds.mdx
@@ -126,7 +126,7 @@ The start command is run to start your Node application once it is deployed. By 
 ```
 
 ## Rebuild an environment via webhook
-Note - at the moment this feature is open to a limited number of Atlas users. If you would like to use it, let us know through [e-mail](sendto:ilona.kedracka@wpengine.com).
+Note - at the moment this feature is open to a limited number of Atlas users. If you would like to use it, let us know through the [form](https://forms.gle/XwqXKaAZcx5u1rhY6).
 
 To generate a webhook that will rebuild your Atlas environment when triggered, visit the environment settings page and click on the `Settings` button:
 


### PR DESCRIPTION
Hi! I'm replacing the broken "sendto:" tag with URL to the sign-up form for webhooks. Thanks!