### PR TITLE
Update build docs with build worker info [NEB-1368]

### DIFF
--- a/atlas/customization/builds.mdx
+++ b/atlas/customization/builds.mdx
@@ -7,7 +7,7 @@ description: Learn how to configure builds on the Atlas platform
 This guide describes how to configure the Atlas build system for your applications.
 
 ## Build Workers
-We optimise the number of workers your Next and Gatsby build uses, see your framework docs for how to adjust this.
+The build system optimises the number of workers your Next and Gatsby build uses, see your framework docs for how to adjust this.
 
 ## Setting a custom version of Node.js, npm and Yarn
 

--- a/atlas/customization/builds.mdx
+++ b/atlas/customization/builds.mdx
@@ -6,6 +6,9 @@ description: Learn how to configure builds on the Atlas platform
 
 This guide describes how to configure the Atlas build system for your applications.
 
+## Build Workers
+We optimise the number of workers your Next and Gatsby build uses, see your framework docs for how to adjust this.
+
 ## Setting a custom version of Node.js, npm and Yarn
 
 ### Node.js


### PR DESCRIPTION
- Add info about build workers for Gatsby and Next.js