### PR TITLE
Add .wordpress-cache to cached folders

### DIFF
--- a/atlas/customization/builds.mdx
+++ b/atlas/customization/builds.mdx
@@ -174,10 +174,11 @@ Atlas caches common framework assets between builds to optimise build times.
 
 The folders that are cached currently are: 
 
-* .next/cache
-* public/
 * .cache
+* .next/cache
 * .nuxt
+* .wordpress-cache
+* public/
 
 If any of the above folders are in the projects root directory at the start of the build, the build will **not** override them. 
 

--- a/atlas/customization/builds.mdx
+++ b/atlas/customization/builds.mdx
@@ -174,11 +174,11 @@ Atlas caches common framework assets between builds to optimise build times.
 
 The folders that are cached currently are: 
 
-* .cache
-* .next/cache
-* .nuxt
-* .wordpress-cache
-* public/
+* `.cache`
+* `.next/cache`
+* `.nuxt`
+* `.wordpress-cache`
+* `public`
 
 If any of the above folders are in the projects root directory at the start of the build, the build will **not** override them. 
 


### PR DESCRIPTION
This folder is used by the [gatsby-source-wordpress](https://www.gatsbyjs.com/plugins/gatsby-source-wordpress/) plugin and is now cached as part of builds.