### PR TITLE
feat: 🎸 ORN-1889 Hide atlas search public api docs from sidebar

### DIFF
--- a/atlas-search/config.json
+++ b/atlas-search/config.json
@@ -18,16 +18,6 @@
       "type": "doc",
       "label": "Using Atlas Search",
       "filePath": "/atlas-search/using-atlas-search.mdx"
-    },
-    {
-      "type": "doc",
-      "label": "Search API",
-      "filePath": "/atlas-search/public-api/search.md"
-    },
-    {
-      "type": "doc",
-      "label": "Index & Delete API",
-      "filePath": "/atlas-search/public-api/index.md"
     }
   ]
 }


### PR DESCRIPTION
We still in development of Atlas Search public API so for now we want to hide it from the menu.